### PR TITLE
[refactor] 인증/비인증 라우터 분리

### DIFF
--- a/packages/admin/src/components/common/ProtectedRoute.tsx
+++ b/packages/admin/src/components/common/ProtectedRoute.tsx
@@ -1,0 +1,12 @@
+import { getCookies } from "@mozu/util-config";
+import { Navigate, Outlet } from "react-router-dom";
+
+export const ProtectedRoute = () => {
+  const accessToken = getCookies<string>("accessToken");
+
+  if (!accessToken) {
+    return <Navigate to="/signin" replace />;
+  }
+
+  return <Outlet />;
+};

--- a/packages/admin/src/components/common/index.ts
+++ b/packages/admin/src/components/common/index.ts
@@ -1,3 +1,4 @@
 export * from "./ArticleTables";
 export * from "./FullPageLoader";
+export * from "./ProtectedRoute";
 export * from "./StockTables";

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -1,106 +1,12 @@
 import { createBrowserRouter } from "react-router-dom";
-import { AppLayout } from "@/layout";
-import * as pages from "@/pages";
+import { ProtectedRoute } from "@/components";
+import { protectedRoutes, publicRoutes } from "./routes";
 
 export const Router = createBrowserRouter([
+  // 인증이 필요한 페이지(로그인을 해야 접근할 수 있는 페이지)는 ProtectedRoute로 묶음, 인증이 필요하지 않은 페이지(로그인, 회원가입 페이지 등)은 publicRoutes 사용
   {
-    path: "/",
-    element: <AppLayout />,
-    children: [
-      {
-        path: "stock-management",
-        children: [
-          {
-            index: true,
-            element: <pages.StockManagementPage />,
-          },
-          {
-            path: ":id",
-            children: [
-              {
-                index: true,
-                element: <pages.StockManagementPage />,
-              },
-              {
-                path: "edit",
-                element: <pages.StockManagementEditPage />,
-              },
-            ],
-          },
-          {
-            path: "add",
-            element: <pages.StockManagementAddPage />,
-          },
-        ],
-      },
-      {
-        path: "article-management",
-        children: [
-          {
-            index: true,
-            element: <pages.ArticleManagementPage />,
-          },
-          {
-            path: ":id",
-            children: [
-              {
-                index: true,
-                element: <pages.ArticleManagementPage />,
-              },
-              {
-                path: "edit",
-                element: <pages.ArticleManagementEditPage />,
-              },
-            ],
-          },
-          {
-            path: "add",
-            element: <pages.ArticleManagementAddPage />,
-          },
-        ],
-      },
-      {
-        path: "class-management",
-        children: [
-          {
-            index: true,
-            element: <pages.ClassManagement />,
-          },
-          {
-            path: ":id",
-            children: [
-              {
-                index: true,
-                element: <pages.ClassEnvironment />,
-              },
-              {
-                path: "edit",
-                element: <pages.ClassEdit />,
-              },
-              {
-                path: "start",
-                element: <pages.InvestmentPreparation />,
-              },
-              {
-                path: "monitoring",
-                element: <pages.ImprovedClassMonitoringPage />,
-              },
-            ],
-          },
-          {
-            path: "create",
-            element: <pages.CreateClass />,
-          },
-        ],
-      },
-    ],
+    element: <ProtectedRoute />,
+    children: protectedRoutes,
   },
-  {
-    path: "/signin",
-    element: <pages.SignInPage />,
-  },
-  {
-    path: "*", // 404 페이지
-    element: <div>404</div>,
-  },
+  ...publicRoutes,
 ]);

--- a/packages/admin/src/routes/index.ts
+++ b/packages/admin/src/routes/index.ts
@@ -1,0 +1,2 @@
+export * from "./protected";
+export * from "./public";

--- a/packages/admin/src/routes/protected.tsx
+++ b/packages/admin/src/routes/protected.tsx
@@ -1,0 +1,98 @@
+import { AppLayout } from "@/layout";
+import * as pages from "@/pages";
+
+export const protectedRoutes = [
+  //인증이 필요한 페이지들
+  {
+    path: "/",
+    element: <AppLayout />,
+    children: [
+      {
+        path: "stock-management",
+        children: [
+          {
+            index: true,
+            element: <pages.StockManagementPage />,
+          },
+          {
+            path: ":id",
+            children: [
+              {
+                index: true,
+                element: <pages.StockManagementPage />,
+              },
+              {
+                path: "edit",
+                element: <pages.StockManagementEditPage />,
+              },
+            ],
+          },
+          {
+            path: "add",
+            element: <pages.StockManagementAddPage />,
+          },
+        ],
+      },
+      {
+        path: "article-management",
+        children: [
+          {
+            index: true,
+            element: <pages.ArticleManagementPage />,
+          },
+          {
+            path: ":id",
+            children: [
+              {
+                index: true,
+                element: <pages.ArticleManagementPage />,
+              },
+              {
+                path: "edit",
+                element: <pages.ArticleManagementEditPage />,
+              },
+            ],
+          },
+          {
+            path: "add",
+            element: <pages.ArticleManagementAddPage />,
+          },
+        ],
+      },
+      {
+        path: "class-management",
+        children: [
+          {
+            index: true,
+            element: <pages.ClassManagement />,
+          },
+          {
+            path: ":id",
+            children: [
+              {
+                index: true,
+                element: <pages.ClassEnvironment />,
+              },
+              {
+                path: "edit",
+                element: <pages.ClassEdit />,
+              },
+              {
+                path: "start",
+                element: <pages.InvestmentPreparation />,
+              },
+              {
+                path: "monitoring",
+                element: <pages.ImprovedClassMonitoringPage />,
+              },
+            ],
+          },
+          {
+            path: "create",
+            element: <pages.CreateClass />,
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/packages/admin/src/routes/public.tsx
+++ b/packages/admin/src/routes/public.tsx
@@ -1,0 +1,13 @@
+import * as pages from "@/pages";
+
+export const publicRoutes = [
+  //인증이 필요하지 않은 페이지들
+  {
+    path: "/signin",
+    element: <pages.SignInPage />,
+  },
+  {
+    path: "*",
+    element: <div>404</div>,
+  },
+];

--- a/packages/student/src/components/common/ProtectedRoute.tsx
+++ b/packages/student/src/components/common/ProtectedRoute.tsx
@@ -1,0 +1,12 @@
+import { getCookies } from "@mozu/util-config";
+import { Navigate, Outlet } from "react-router-dom";
+
+export const ProtectedRoute = () => {
+  const accessToken = getCookies<string>("accessToken");
+
+  if (!accessToken) {
+    return <Navigate to="/signin" replace />;
+  }
+
+  return <Outlet />;
+};

--- a/packages/student/src/components/common/index.ts
+++ b/packages/student/src/components/common/index.ts
@@ -1,0 +1,1 @@
+export * from "./ProtectedRoute";

--- a/packages/student/src/components/index.ts
+++ b/packages/student/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./common";
 export * from "./home";
 export * from "./news";
 export * from "./result";

--- a/packages/student/src/router.tsx
+++ b/packages/student/src/router.tsx
@@ -1,7 +1,7 @@
 import { createBrowserRouter, Navigate } from "react-router-dom";
 import { AppLayout, MockAppLayout } from "@/layout";
 import * as pages from "@/pages";
-import { StockGraph, StockInfo } from "./components";
+import { ProtectedRoute, StockGraph, StockInfo } from "./components";
 
 export const Router = createBrowserRouter([
   {
@@ -18,56 +18,56 @@ export const Router = createBrowserRouter([
     ],
   },
   {
-    path: "/:classId",
-    element: <AppLayout />,
+    element: <ProtectedRoute />,
     children: [
       {
-        index: true,
-        element: <pages.HomePage />,
-      },
-      {
-        path: "stock/:stockId",
-        element: <pages.StockPage />,
+        path: "/:classId",
+        element: <AppLayout />,
         children: [
           {
             index: true,
-            element: (
-              <Navigate
-                to="stock-info"
-                replace
-              />
-            ),
+            element: <pages.HomePage />,
           },
           {
-            path: "price-info",
-            element: <StockGraph />,
+            path: "stock/:stockId",
+            element: <pages.StockPage />,
+            children: [
+              {
+                index: true,
+                element: <Navigate to="stock-info" replace />,
+              },
+              {
+                path: "price-info",
+                element: <StockGraph />,
+              },
+              {
+                path: "stock-info",
+                element: <StockInfo />,
+              },
+            ],
           },
           {
-            path: "stock-info",
-            element: <StockInfo />,
+            path: "news",
+            children: [
+              {
+                index: true,
+                element: <pages.NewsPage />,
+              },
+              {
+                path: ":newsId",
+                element: <pages.NewsDetailPage />,
+              },
+            ],
+          },
+          {
+            path: "result",
+            element: <pages.ResultPage />,
+          },
+          {
+            path: "ending",
+            element: <pages.EndingPage />,
           },
         ],
-      },
-      {
-        path: "news",
-        children: [
-          {
-            index: true,
-            element: <pages.NewsPage />,
-          },
-          {
-            path: ":newsId",
-            element: <pages.NewsDetailPage />,
-          },
-        ],
-      },
-      {
-        path: "result",
-        element: <pages.ResultPage />,
-      },
-      {
-        path: "ending",
-        element: <pages.EndingPage />,
       },
     ],
   },


### PR DESCRIPTION
## #️⃣연관된 이슈

> #183 

## 📝작업 내용

### 1. ProtectedRoute 컴포넌트 생성

  각 패키지(admin, student)의 src/components/common 디렉터리에 ProtectedRoute.tsx 컴포넌트를 추가했습니다. 이 컴포넌트는 다음과 같은 역할을 합니다.

   - 인증 상태 확인: 사용자의 accessToken 쿠키 유무를 확인하여 로그인 상태를 판단합니다.
   - 접근 제어:
       - 로그인 상태(accessToken 존재)이면 요청된 페이지(children)를 정상적으로 보여줍니다.
       - 비로그인 상태(accessToken 부재)이면 사용자를 /signin 페이지로 즉시 리디렉션하여 비인가 접근을 차단합니다.

###  2. 라우트 구조 개편

  각 패키지의 라우팅 설정(router.tsx)을 수정하여 인증이 필요한 경로와 필요하지 않은 경로를 명확히 분리했습니다.

   - `admin` 패키지:
       - src/routes 디렉터리를 신설하고, 인증이 필요한 라우트(protected.tsx)와 필요 없는 라우트(public.tsx)를 분리하여 정의했습니다.
       - router.tsx에서는 이 두 라우트 그룹을 가져와 ProtectedRoute 컴포넌트로 인증 필요한 라우트들을 감싸도록 설정했습니다.

   - `student` 패키지:
       - 기존 router.tsx 파일 내에서 ProtectedRoute를 적용하여, 수업 관련 페이지(/:classId 경로)에 접근할 때 반드시 인증을 거치도록 수정했습니다.
       - 로그인, 테스트용 목업 페이지 등 인증이 필요 없는 경로는 그대로 접근 가능하도록 유지했습니다.

  ### 기대 효과

   - 보안 강화: 인증된 사용자만 핵심 페이지에 접근할 수 있도록 하여 보안 수준을 높였습니다.
   - 사용자 경험 개선: 비로그인 사용자가 보호된 페이지에 접근 시, 화면 깜빡임 없이 즉시 로그인 페이지로 이동시켜 자연스러운 경험을 제공합니다.
   - 코드 구조 개선: 라우팅 로직에서 인증 여부를 명시적으로 분리하여 코드의 가독성과 유지보수성을 향상했습니다.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 인증 라우트 가드 도입: 로그인 토큰 없을 시 /signin으로 리다이렉트. 관리자·학생 앱 모두 적용.
- 리팩터링
  - 관리자: 라우팅을 공용(public)/보호(protected) 구성으로 분리하고 Router를 래퍼 기반으로 단순화.
  - 학생: /:classId 경로에 ProtectedRoute 적용, 기본 진입을 홈으로 변경. 주식 상세 하위에 뉴스 트리를 재구성해 result/ending를 뉴스 하위로 통합. price-info/stock-info 경로 및 기본 리다이렉트 흐름 정비.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->